### PR TITLE
getId() to getProductId()

### DIFF
--- a/app/code/G2A/Pay/Helper/Data.php
+++ b/app/code/G2A/Pay/Helper/Data.php
@@ -132,7 +132,7 @@ final class Data extends AbstractHelper
         /** @var \Magento\Sales\Model\Order\Item $item */
         foreach ($items as $item) {
             $qty       = $item->getQtyOrdered();
-            $productId = $item->getId();
+            $productId = $item->getProductId();
             $itemPrice = $this->roundToTwoDecimal($item->getPrice() - $item->getDiscountAmount());
             $data[]    = [
                 'qty'    => $qty,


### PR DESCRIPTION
Incorrectly getting the product ID.
Currently results in wrong product url's being returned or Exception (Magento\Framework\Exception\NoSuchEntityException): Requested product doesn't exist.